### PR TITLE
Job Search - Job Number, then "Enter" jumps straight to job

### DIFF
--- a/all/content/all.js
+++ b/all/content/all.js
@@ -234,14 +234,13 @@ $(function(){
   // Shortcuts search box - if Job Number entered, jump straight to that job
   $('form#layoutJobSearchForm')
     .on('submit',function(e){
-      e.preventDefault();
       var $t = $(this) ,
           $q = $('#layoutJobSearchFormJobQuery',$t) ,
           val = $q.val();
-      if ( val.match(/^\d{0,4}\-?\d{4}$/) ) { // If Keydown is "Enter" and the field contains 4 or more digits and nothing else
+      if ( /^\d{0,4}\-?\d{4}$/.test( val ) ) { // If Keydown is "Enter" and the field contains 4 or more digits and nothing else
         document.location.pathname = '/Jobs/' + parseInt( val.replace(/\D/g,'') , 10 );
-      } else {
-        document.location.href = '/Jobs?q=' + encodeURIComponent( val );
+        e.preventDefault();
+        e.stopImmediatePropagation();
       }
     });
 

--- a/all/content/all.js
+++ b/all/content/all.js
@@ -227,3 +227,20 @@ function whenWeAreReady(varToCheck,cb) { //when external vars have loaded
     }
   }, 200);
 }
+
+
+$(document).ready(function($){
+
+  // Shortcuts search box - if Job Number entered, jump straight to that job
+  $('#layoutJobSearchFormJobQuery')
+    .on('keydown',function(e){
+      var $t = $(this) ,
+          val = $t.val();
+      if ( e.which === 13 && val.match(/^\d+\-?\d{4}$/) ) { // If Keydown is "Enter" and the field contains 4 or more digits and nothing else
+        console.log( 'Number Only Search' );
+        e.preventDefault();
+        document.location.pathname = '/Jobs/' + parseInt( val.replace(/\D/g,'') , 10 );
+      }
+    });
+
+});

--- a/all/content/all.js
+++ b/all/content/all.js
@@ -229,17 +229,19 @@ function whenWeAreReady(varToCheck,cb) { //when external vars have loaded
 }
 
 
-$(document).ready(function($){
+$(function(){
 
   // Shortcuts search box - if Job Number entered, jump straight to that job
-  $('#layoutJobSearchFormJobQuery')
-    .on('keydown',function(e){
+  $('form#layoutJobSearchForm')
+    .on('submit',function(e){
+      e.preventDefault();
       var $t = $(this) ,
-          val = $t.val();
-      if ( e.which === 13 && val.match(/^\d+\-?\d{4}$/) ) { // If Keydown is "Enter" and the field contains 4 or more digits and nothing else
-        console.log( 'Number Only Search' );
-        e.preventDefault();
+          $q = $('#layoutJobSearchFormJobQuery',$t) ,
+          val = $q.val();
+      if ( val.match(/^\d{0,4}\-?\d{4}$/) ) { // If Keydown is "Enter" and the field contains 4 or more digits and nothing else
         document.location.pathname = '/Jobs/' + parseInt( val.replace(/\D/g,'') , 10 );
+      } else {
+        document.location.href = '/Jobs?q=' + encodeURIComponent( val );
       }
     });
 


### PR DESCRIPTION
Entering a Job Number into the "Job Search" box and then hitting Enter bypasses the Beacon Search function and jumps straight to that job number.

Tested with patterns: "000x-xxxx", "x-xxxx", "xxxxx"
Noted to be MUCH faster!