### PR TITLE
KeepAlive Change - No Prompt if Beacon Window Focused

### DIFF
--- a/all/all.js
+++ b/all/all.js
@@ -6,7 +6,12 @@ chrome.runtime.sendMessage({activity: true});
 // notify keep alive system whenever we click on something. We let the event
 // propagate because we don't want to interfere with regular operation of <a>
 $('a').click(function(e) {
-  chrome.runtime.sendMessage({activity: true});
+  chrome.runtime.sendMessage({activity: true, link: this});
+});
+// notify keepalive system 
+$(window).focus(function(){
+  console.log('Focus');
+  chrome.runtime.sendMessage({focus: true});
 });
 
 // inject JS that is to run on every page in page context


### PR DESCRIPTION
Added code to **all.js** which sends a message to **background.js** when any beacon window gains focus. On receipt of this message, a `lastActivity` variable is set to that timestamp.

When the KeepAlive timer expires, if the `lastActivity` timestamp is within the timer period, it is presumed that the session should be kept alive, and no prompt is shown. If the `lastActivity` timestamp is outside of the timer period, then the prompt is shown (as is the case now).

Hopefully this will find a happy balance between keeping users logged in, and not keeping sessions running unnecessarily.