### PR TITLE
Removed "200" choice from pageSizeChoices

### DIFF
--- a/Jobs/content/Tasking.js
+++ b/Jobs/content/Tasking.js
@@ -1,5 +1,4 @@
 //More pageination choices!
-taskingViewModel.pageSizeChoices.push(200);
 taskingViewModel.pageSizeChoices.push(500);
 taskingViewModel.pageSizeChoices.push(1000);
 


### PR DESCRIPTION
Resolving Issue #27.
Original choices had "250" as the maximum. Adding "200" made it out of order.